### PR TITLE
Update of Makefile, invoke_requests.py and readme 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ endif
 .PHONY: help
 .DEFAULT_GOAL := help
 
+SHELL:= /bin/zsh
+#export REPLICATE_API_TOKEN='5b48a9692b7df426b1db19d0f0b6a7d995e309eb'
+
 help: ## get a list of all the targets, and their short descriptions
 	@# source for the incantation: https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' Makefile | awk 'BEGIN {FS = ":.*?##"}; {printf "\033[36m%-12s\033[0m %s\n", $$1, $$2}'
@@ -18,6 +21,8 @@ deploy: cog_build cog_push ## deploys to replicate
 test: local_inference ## runs a local inference from scratch
 
 remote_inference: ## runs an example inference on replicate, higher latencies in the minute range
+#	$(info $(SHELL))
+	$(info $(REPLICATE_API_TOKEN))
 	python invoke_requests.py
 
 local_inference: wandb model_weights ## runs an example inference locally

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,6 @@ endif
 .PHONY: help
 .DEFAULT_GOAL := help
 
-SHELL:= /bin/zsh
-#export REPLICATE_API_TOKEN='5b48a9692b7df426b1db19d0f0b6a7d995e309eb'
-
 help: ## get a list of all the targets, and their short descriptions
 	@# source for the incantation: https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' Makefile | awk 'BEGIN {FS = ":.*?##"}; {printf "\033[36m%-12s\033[0m %s\n", $$1, $$2}'
@@ -21,9 +18,7 @@ deploy: cog_build cog_push ## deploys to replicate
 test: local_inference ## runs a local inference from scratch
 
 remote_inference: ## runs an example inference on replicate, higher latencies in the minute range
-#	$(info $(SHELL))
-	$(info $(REPLICATE_API_TOKEN))
-	python invoke_requests.py
+	python invoke_requests.py --token $(REPLICATE_API_TOKEN) --version $(MODEL_VERSION)
 
 local_inference: wandb model_weights ## runs an example inference locally
 	cog predict -i image=https://fsdl-public-assets.s3-us-west-2.amazonaws.com/paragraphs/a01-077.png

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ of the inference container.
 ## Deployment
 
 To deploy a model and run inference on `replicate`,
-you'll also need a [Replicate account](https://replicate.com/join).
+you'll also need a [Replicate account](https://replicate.com/join).  
 After you've set one up,
 create a `.env` file
-and add your user name and API token.
+and add your user name and API token, and 'Create a new model' on your account with the name 'text-recognizer-gpu'. 
 Then, run `make cog_push`
 and copy the model version number into the `.env` file as well.
 Finally, run `make remote_inference` to test

--- a/invoke_requests.py
+++ b/invoke_requests.py
@@ -3,35 +3,24 @@ import json
 import os
 import requests
 import time
-
-from dotenv import load_dotenv
-
-# load_dotenv()  # get environment variables
-
-# replicate_api_token = os.environ["REPLICATE_API_TOKEN"]
-
-# print(f"Token {replicate_api_token}")
-
+import argparse
 
 REPLICATE_API_URL =  "https://api.replicate.com/v1/predictions"
 EXAMPLE_URL = "https://fsdl-public-assets.s3-us-west-2.amazonaws.com/paragraphs/a01-077.png"
 
-def predict_replicate(api_token, model_version, image_url=EXAMPLE_URL):
-
-    print(f"Token {api_token}")
-    print(f"Version {model_version}")
+def predict_replicate(args, api_url=REPLICATE_API_URL, image_url=EXAMPLE_URL):
 
     headers = {
-            "Authorization": f"Token {api_token}",
+            "Authorization": f"Token {str(args.token)}",
             "Content-Type": "application/json"
         }
 
     data = {
-        "version": model_version,
+        "version": str(args.version),
         "input": {"image": image_url}
     }
 
-    response = requests.post(REPLICATE_API_URL, headers=headers, data=json.dumps(data))
+    response = requests.post(api_url, headers=headers, data=json.dumps(data))
     response.raise_for_status()
 
     if response.status_code == 201:
@@ -60,17 +49,11 @@ def _get_from_replicate(get_url, headers):
             time.sleep(0.5)
 
 
-def _setup_secrets():
-    load_dotenv()  # get environment variables
-
-    replicate_api_token = os.environ["REPLICATE_API_TOKEN"]
-    assert replicate_api_token is not None, "define $REPLICATE_API_TOKEN to perform remote inference"
-
-    model_version = os.environ["MODEL_VERSION"]
-    assert model_version is not None, "define $MODEL_VERSION to perform remote inference"
-
-    return replicate_api_token, model_version
-
-
 if __name__ == "__main__":
-    print(predict_replicate(*_setup_secrets()))
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--token", type=str, help='pass in REPLICATE_API_TOKEN as a string', required=True)
+    parser.add_argument("--version", type=str, help='pass in MODEL_VERSION as a string', required=True)
+    args = parser.parse_args()
+
+    print(predict_replicate(args))

--- a/invoke_requests.py
+++ b/invoke_requests.py
@@ -6,12 +6,20 @@ import time
 
 from dotenv import load_dotenv
 
+# load_dotenv()  # get environment variables
+
+# replicate_api_token = os.environ["REPLICATE_API_TOKEN"]
+
+# print(f"Token {replicate_api_token}")
 
 
-REPLICATE_API_URL = "https://api.replicate.com/v1/predictions"
+REPLICATE_API_URL =  "https://api.replicate.com/v1/predictions"
 EXAMPLE_URL = "https://fsdl-public-assets.s3-us-west-2.amazonaws.com/paragraphs/a01-077.png"
 
 def predict_replicate(api_token, model_version, image_url=EXAMPLE_URL):
+
+    print(f"Token {api_token}")
+    print(f"Version {model_version}")
 
     headers = {
             "Authorization": f"Token {api_token}",


### PR DESCRIPTION
This PR updates files to get the text-recgonizer model to run on a wsl2 ubuntu 20.04 instance. 

The issue in running them with the original code was that the `make remote_inference` command would return an authentication error, potentially due to both the `makefile` and and `invoke_requests.py` pulling in environmental variables with the same name.

Therefore:
* `invoke_requests.py` is updated to take command line arguments for the API token and model version
* `makefile` is updated to reflect this change
* and the `readme `is also updated to reflect the need to create a model on the replicate account in order to push the model successfully (so not to do with the above issue)